### PR TITLE
Import inputs column enhancement

### DIFF
--- a/FrEDI/R/import_inputs.R
+++ b/FrEDI/R/import_inputs.R
@@ -214,10 +214,18 @@ import_inputs <- function(
   hasPop     <- df_pop |> length()
   if(hasPop) df_pop <- df_pop |> calc_import_pop(popArea=popArea)
   if(!(df_pop |> is.null())) {
+    ### Rename state_pop columne
+    doRename <- "state_pop" %in% (data1 |> names())
+    if(doRename) {
+      rename0  <- c("state_pop")
+      renameTo <- c("pop")
+      df_pop   <- df_pop |> rename_at(c(rename0), ~renameTo)
+    } ### End if(doRename)
+    ### Update in output
     inputsList[["pop"]] <- df_pop
   } else {
     inputsList["pop"] <- list(NULL)
-  }
+  } ### End if(!(df_pop |> is.null()))
 
   ###### Rename List ######
   inputsList <- inputsList |> set_names(outNames)

--- a/FrEDI/R/import_inputs.R
+++ b/FrEDI/R/import_inputs.R
@@ -123,18 +123,22 @@ import_inputs <- function(
 
   ###### Load Data from FrEDI ######
   ### Get objects from FrEDI name space
-  ### Get input scenario info: co_inputScenarioInfo
+  ### Get input scenario info: co_info
   ### Get state info: co_states
-  fListNames <- c("co_inputScenarioInfo", "co_states")
-  sListNames <- c("df_popRatios")
-  for(name_i in fListNames){name_i |> assign(rDataList[["frediData"]][["data"]][[name_i]]); rm(name_i)}
-  for(name_i in sListNames){name_i |> assign(rDataList[["stateData"]][["data"]][[name_i]]); rm(name_i)}
+  co_info   <- "co_inputScenarioInfo" |> get_frediDataObj("frediData")
+  co_states <- "co_states"    |> get_frediDataObj("frediData")
+  df_ratios <- "df_popRatios" |> get_frediDataObj("stateData")
+  # fListNames <- c("co_info", "co_states")
+  # sListNames <- c("df_ratios")
+  # for(name_i in fListNames){name_i |> assign(rDataList[["frediData"]][["data"]][[name_i]]); rm(name_i)}
+  # for(name_i in sListNames){name_i |> assign(rDataList[["stateData"]][["data"]][[name_i]]); rm(name_i)}
 
 
   ###### Defaults ######
   ### Input names, output names
   inNames    <- c("temp", "slr", "gdp", "pop")
   outNames   <- inNames |> paste0("Input")
+  nInputs    <- inNames |> length()
   ### Valid values
   tempTypes  <- c("global", "conus")
   popAreas   <- c("national", "conus", "regional", "state")
@@ -200,7 +204,9 @@ import_inputs <- function(
     inputName = inNames,
     inputDf   = inputsList,
     valCol    = valCols,
-    idCol     = idCols
+    idCol     = idCols,
+    tempType  = tempType |> rep(nInputs),
+    popArea   = popArea |> rep(nInputs)
   ) |>
     pmap(check_input_data) |>
     set_names(inNames)
@@ -210,22 +216,24 @@ import_inputs <- function(
   ### Calculate state population if pop input present and popArea != "state"
   ### Then check values
   # if(hasInputs) msgN |> paste0(msg1, "Checking population values...") |> message()
-  df_pop     <- inputsList[["pop"]]
-  hasPop     <- df_pop |> length()
-  if(hasPop) df_pop <- df_pop |> calc_import_pop(popArea=popArea)
-  if(!(df_pop |> is.null())) {
-    ### Rename state_pop columne
-    doRename <- "state_pop" %in% (data1 |> names())
-    if(doRename) {
-      rename0  <- c("state_pop")
-      renameTo <- c("pop")
-      df_pop   <- df_pop |> rename_at(c(rename0), ~renameTo)
-    } ### End if(doRename)
-    ### Update in output
-    inputsList[["pop"]] <- df_pop
-  } else {
-    inputsList["pop"] <- list(NULL)
-  } ### End if(!(df_pop |> is.null()))
+  # df_pop     <- inputsList[["pop"]]
+  # hasPop     <- df_pop |> length()
+  # if(hasPop) df_pop <- df_pop |> calc_import_pop(popArea=popArea)
+  # if(!(df_pop |> is.null())) {
+  #   ### Rename state_pop columne
+  #   doRename <- "state_pop" %in% (data1 |> names())
+  #   if(doRename) {
+  #     rename0  <- c("state_pop")
+  #     renameTo <- c("pop")
+  #     df_pop   <- df_pop |> rename_at(c(rename0), ~renameTo)
+  #   } ### End if(doRename)
+  #   ### Update in output
+  #   inputsList[["pop"]] <- df_pop
+  # } else {
+  #   inputsList["pop"] <- list(NULL)
+  # } ### End if(!(df_pop |> is.null()))
+
+
 
   ###### Rename List ######
   inputsList <- inputsList |> set_names(outNames)

--- a/FrEDI/R/import_inputs.R
+++ b/FrEDI/R/import_inputs.R
@@ -212,29 +212,6 @@ import_inputs <- function(
     set_names(inNames)
 
 
-  ###### Calculate State Population ######
-  ### Calculate state population if pop input present and popArea != "state"
-  ### Then check values
-  # if(hasInputs) msgN |> paste0(msg1, "Checking population values...") |> message()
-  # df_pop     <- inputsList[["pop"]]
-  # hasPop     <- df_pop |> length()
-  # if(hasPop) df_pop <- df_pop |> calc_import_pop(popArea=popArea)
-  # if(!(df_pop |> is.null())) {
-  #   ### Rename state_pop columne
-  #   doRename <- "state_pop" %in% (data1 |> names())
-  #   if(doRename) {
-  #     rename0  <- c("state_pop")
-  #     renameTo <- c("pop")
-  #     df_pop   <- df_pop |> rename_at(c(rename0), ~renameTo)
-  #   } ### End if(doRename)
-  #   ### Update in output
-  #   inputsList[["pop"]] <- df_pop
-  # } else {
-  #   inputsList["pop"] <- list(NULL)
-  # } ### End if(!(df_pop |> is.null()))
-
-
-
   ###### Rename List ######
   inputsList <- inputsList |> set_names(outNames)
 

--- a/FrEDI/R/run_fredi.R
+++ b/FrEDI/R/run_fredi.R
@@ -48,7 +48,7 @@
 #'    * GDP inputs must have at least one non-missing value in 2010 or earlier and at least one non-missing value in or after the final analysis year (as specified by `maxYear`).
 #'    * If the user does not specify an input scenario for GDP (i.e., `inputsList = list(gdpInput = NULL)`, [FrEDI::run_fredi()] uses a default GDP scenario.
 #' * __Population Inputs.__ The input population scenario requires state-level population values. Population values must be greater than or equal to zero.
-#'    * `popInput` requires a data frame object with five columns with names `"year"`, `"region"`, `"state"`, `"postal"`, and `"state_pop"` containing the year, the NCA region name, the state name, the postal code abbreviation for the state, and the state population, respectively.
+#'    * `popInput` requires a data frame object with five columns with names `"region"`, `"state"`, `"postal"`, `"year"`, and `"state"` containing the year, the NCA region name, the state name, the postal code abbreviation for the state, and the state population, respectively.
 #'    * Population inputs must have at least one non-missing value in 2010 or earlier and at least one non-missing value in or after the final analysis year (as specified by `maxYear`).
 #'    * If the user does not specify an input scenario for population (i.e., `inputsList = list(popInput = NULL)`, [FrEDI::run_fredi()] uses a default population scenario.
 #'
@@ -567,7 +567,6 @@ run_fredi <- function(
   ### Add to list
   if(outputList){
     statusList[["inputsList"]][["gdpInput"]] <- has_gdpUpdate |> ifelse("Custom", "Default")
-    # argsList  [["inputsList"]][["gdpInput"]] <- inputsList[["gdpInput"]]
     argsList  [["inputsList"]][["gdpInput"]] <- gdpInput
   } ### End if(outputList)
   rm(gdpInput, gdp_default, has_gdpUpdate)
@@ -575,6 +574,17 @@ run_fredi <- function(
   ### Population inputs
   if(has_popUpdate){
     "\t" |> message("Creating population scenario from user inputs...")
+    ### Rename any columns
+    # rename0   <- "state_pop"
+    # renameTo  <- popCol0
+    rename0   <- "pop"
+    renameTo  <- popCol0
+    doRename0 <- rename0 %in% (popInput |> names())
+    if(doRename0) {
+      popInput <- popInput |> rename_at(c(rename0), ~renameTo)
+    } ### End if(doRename0)
+    rm(rename0, renameTo, doRename0)
+
     ### Standardize region and then interpolate
     popInput     <- popInput  |> filter_all(all_vars(!(. |> is.na())))
     popInput     <- popInput  |> filter_at(c(popCol0), function(y){y >= 0})

--- a/FrEDI/R/utils_import_inputs.R
+++ b/FrEDI/R/utils_import_inputs.R
@@ -620,7 +620,7 @@ check_input_data <- function(
     doCalc  <- !("state" %in% popArea )
     if(doCalc) {
       msg_pop <- paste0("Calculating state population from ", popArea, " values...")
-      msgN |> paste0(msg2_i, msg_pop) |> message()
+      paste0(msg1_i, msg_pop) |> message()
       inputDf <- inputDf |> calc_import_pop(popArea=popArea)
     } ### End if(doCalc)
     ### Rename state population column


### PR DESCRIPTION
Added flexibility to column names: Now, if the driver column is not found, the import_inputs helper function will try to string match the input type against column names. If it finds a match: 

- If a temperature input, it will look for matches to strings "conus" and "global". If conus matches, it will use that column and set tempType to "conus". Else if global matches, it will use that column and set tempType to "global". Otherwise, it will use the first matched column. 
- If a population input, it will look for matches to strings "state", "region", "conus", and "global". It will check for a match and use the first associated column, and set popArea accordingly. E.g., if "reg_pop" is present, but "state_pop" isn't, "reg_pop" will be used and the popArea set to "regional".
- Otherwise, the first matched column will be used as the value column.

The function will then rename the matched column to the expected column. 

No flexibility enhancements were made for ID columns.
