### PR TITLE
Update convertTemps to handle variation in case of `from` arg

### DIFF
--- a/FrEDI/R/convertTemps.R
+++ b/FrEDI/R/convertTemps.R
@@ -43,8 +43,7 @@ convertTemps <- function(
     temp_conus <- temps
     new_temps  <- (temp_conus - c0)/c1
   } else {
-    print("Please enter Conus or Global in `from` argument")
-    return()
+    stop("Warning! In convertTemps(): Invalid value provided to from argument. Please enter a valid value. Exiting...")
   }
 
   ###### Return ######

--- a/FrEDI/R/convertTemps.R
+++ b/FrEDI/R/convertTemps.R
@@ -33,13 +33,18 @@ convertTemps <- function(
   c0 <- 0 ### Update
   c1 <- 1.421 ### Update
 
-  toType <- from |> tolower()
-  if(from == "global"){
+  ## Make "from" argument lowercase
+  fromType <- from |> tolower()
+
+  if(fromType == "global"){
     temp_global <- temps
     new_temps   <- c1*temp_global + c0
-  } else{
+  } else if(fromType == "conus"){
     temp_conus <- temps
     new_temps  <- (temp_conus - c0)/c1
+  } else {
+    print("Please enter Conus or Global in `from` argument")
+    return()
   }
 
   ###### Return ######


### PR DESCRIPTION
Previous Behavior:  if there was an uppercase letter in definition of the "from" argument it would effectively run the "conus" conversion part of the function

New Behavior: Conversion now strictly looks for "global" or "conus" after turning the "from" string to lowercase. If "conus" or "global" are not there it prints a statement and returns empty.