### PR TITLE
Add ch4 input column to output if it is a user input

### DIFF
--- a/R/run_fredi_ghg.R
+++ b/R/run_fredi_ghg.R
@@ -364,7 +364,7 @@ run_fredi_ghg <- function(
       # module    = "methane" |> rep(inNames |> length())
       # module    = "ghg" |> rep(inNames |> length())
     ) |>
-      pmap(check_input_data, popArea="state", module="ghg") |>
+      pmap(check_input_data, popArea="state", module="ghg", con = conn) |>
       set_names(inNames)
     rm(minYrs0, maxYrs0)
 
@@ -623,8 +623,10 @@ run_fredi_ghg <- function(
   # valCols0   <- c("physicalmeasure")
   valCols0   <- c()
   sumCols0   <- c("physical_impacts", "annual_impacts")
+  # add input ch4 if provided by user
+  if(has_ch4){ch4Cols0 <- c("CH4_ppbv")} else {ch4Cols0 <- c()}
   # idCols0 |> print(); modCols0 |> print(); natCols0 |> print(); valCols0 |> print(); sumCols0 |> print()
-  select0    <- idCols0 |> c(modCols0, natCols0, valCols0, sumCols0) |> unique()
+  select0    <- idCols0 |> c(modCols0,ch4Cols0, natCols0, valCols0, sumCols0) |> unique()
   arrange0   <- idCols0 |> unique()
 
   ### Select columns

--- a/R/utils_import_inputs.R
+++ b/R/utils_import_inputs.R
@@ -670,9 +670,20 @@ check_input_data <- function(
   ### Get state info: co_states
   #co_info   <- "co_inputInfo"  |> get_frediDataObj(listSub=dListSub0, listName=dListName0)
   #co_states <- "co_states"     |> get_frediDataObj(listSub=dListSub0, listName=dListName0)
+  if(doMain | doSV){
   co_info   <- DBI::dbReadTable(con,"co_inputInfo")
   co_states <- DBI::dbReadTable(con,"co_states")
-
+  }
+  
+  if(doMethane){
+    ghgData    <- DBI::dbReadTable(con,"ghgData")
+    ghgData    <- unserialize(ghgData$value |> unlist())
+    
+    co_info   <- ghgData$ghgData$co_inputInfo
+    co_states <- ghgData$ghgData$co_states
+  }
+  
+  
   # co_region <- "co_regions"    |> get_frediDataObj(listSub=dListSub0, listName=dListName0)
 
 


### PR DESCRIPTION
Closes #252 

Add ch4 input data to output if user defined.

Motivation: If a user inputs ch4, we would like a user to see it in the outputs along with everything else.

Summary of changes:
Use the has_ch4 flag, which is true when ch4 is an input, to add the ch4_ppbv column to output. Also, add a change to check_input_data to us the correct inputinfo table for the ghg module instead of fredi module which doesn't have information on ghg inputs.